### PR TITLE
Allows to specify the folder name where the run will put all the logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,13 +70,13 @@ Please **be careful** on deleting the working directory content because without 
 
 #### Single node cluster teardown
 ```
-<podman|docker> run -v <HOST_WORKDIR_PATH>:/workdir\
+<podman|docker> run -v <HOST_WORKDIR_ABSOLUTE_PATH>:/workdir\
  -e WORKING_MODE=T\
  -e TEARDOWN_RUN_ID=<TEARDOWN_RUN_ID>\ 
  -e AWS_ACCESS_KEY_ID=<AWS_ACCESS_KEY_ID>\
  -e AWS_SECRET_ACCESS_KEY=<AWS_SECRET_ACCESS>\
  -e AWS_DEFAULT_REGION=us-west-2\
- -ti quay.io/crcont/crc-cloud
+ quay.io/crcont/crc-cloud
 ```
 (check [here](#workdir) for **TEARDOWN_RUN_ID** infos and **WORKDIR** setup instructions )
 
@@ -95,12 +95,13 @@ Environment variables will be passed to the container from the command line invo
 | AWS_DEFAULT_REGION | AWS region where the cluster will be deployed ( currently us-west-2 is the only supported)
 
 
+
 **Cluster teardown**
 
 | VARIABLE | DESCRIPTION |
 | --- | ---|
 | WORKING_MODE | T (teardown) |
-| TEARDOWN_ID | the name (unix timestamp format) of the folder created inside the working directory, containing all the metadata needed to teardown the cluster |
+| TEARDOWN_ID | the name of the folder created inside the working directory, containing all the metadata needed to teardown the cluster (if specified in creation will match with CREATE_RUN_ID)|
 | AWS_ACCESS_KEY_ID  | AWS access key (infos [here](#prereq))  |
 | AWS_SECRET_ACCESS_KEY | AWS secret access key (infos [here](#prereq)) |
 | AWS_DEFAULT_REGION | AWS region where the cluster has been deployed ( currently us-west-2 is the only supported) |
@@ -110,6 +111,7 @@ Environment variables will be passed to the container from the command line invo
 
 |  VARIABLE | DESCRIPTION  |
 |---|---|
+| CREATE_RUN_ID | Overrides the folder where the **CRC-Cloud** will put the output files, if not set will use the current timestamp, useful for CI/CD pipelines or everywhere there is the need to know this value upfront |
 |  PASS_DEVELOPER |  overrides the default password (developer) for developer account  |
 |  PASS_KUBEADMIN | overrides the default password (kubeadmin) for kubeadmin account   |
 |  PASS_REDHAT |  overrides the default password (redhat) for redhat account |

--- a/crc-cloud.sh
+++ b/crc-cloud.sh
@@ -17,7 +17,7 @@ prepare_workdir() {
     rm -rf $WORKDIR_PATH/latest
     #link only if not running in container (teardown will need mandatory run id)
     [[ ! $CONTAINER ]] && ln -s $(readlink -f $WORKDIR) $(readlink -f $WORKDIR_PATH)/latest
-    pr_info "preparing working directory"
+    pr_info "preparing working directory: $WORKDIR"
 }
 
 
@@ -209,7 +209,7 @@ teardown() {
 }
 
 set_workdir_dependent_variables() {
-    WORKDIR="$WORKDIR_PATH/$RUN_TIMESTAMP"
+    WORKDIR="$WORKDIR_PATH/$CREATE_RUN_ID"
     LOG_FILE="$WORKDIR/local.log"
     TEARDOWN_LOGFILE="$WORKDIR_PATH/teardown_$RUN_TIMESTAMP.log"
     RANDOM_SUFFIX_FILE="$WORKDIR/suffix"
@@ -274,14 +274,6 @@ FIGLET=`which figlet 2>/dev/null`
 [[ $CONTAINER && ( $? != 0 ) ]] && stop_if_failed 1 "[DEPENDENCY MISSING]: figlet (container mode only), please install it and try again"
 
 
-##DEFAULT VALUES THAT CAN BE OVERRIDDEN BY ENV (podman/docker)
-[ -z $PASS_DEVELOPER ] && PASS_DEVELOPER="developer"
-[ -z $KUBEADMIN ] && PASS_KUBEADMIN="kubeadmin"
-[ -z $PASS_REDHAT ] && PASS_REDHAT="redhat"
-[ -z $INSTANCE_TYPE ] && INSTANCE_TYPE="c6in.2xlarge"
-[ -z $WORKDIR_PATH ] && WORKDIR_PATH="workdir"
-[ -z $WORKING_MODE ] && WORKING_MODE=""
-[ -z $TEARDOWN_RUN_ID ] && TEARDOWN_RUN_ID="latest"
 
 ##CONST
 SSH_PORT="22"
@@ -294,6 +286,16 @@ TEMPLATES="templates"
 TEARDOWN_MAX_RETRIES=500
 CLUSTER_INFOS_TEMPLATE="$TEMPLATES/$CLUSTER_INFOS_FILE"
 AMI_ID="ami-0569ce8a44f2351be"
+
+##DEFAULT VALUES THAT CAN BE OVERRIDDEN BY ENV (podman/docker)
+[ -z $PASS_DEVELOPER ] && PASS_DEVELOPER="developer"
+[ -z $KUBEADMIN ] && PASS_KUBEADMIN="kubeadmin"
+[ -z $PASS_REDHAT ] && PASS_REDHAT="redhat"
+[ -z $INSTANCE_TYPE ] && INSTANCE_TYPE="c6in.2xlarge"
+[ -z $WORKDIR_PATH ] && WORKDIR_PATH="workdir"
+[ -z $WORKING_MODE ] && WORKING_MODE=""
+[ -z $TEARDOWN_RUN_ID ] && TEARDOWN_RUN_ID="latest"
+[ -z $CREATE_RUN_ID ] && CREATE_RUN_ID=$RUN_TIMESTAMP
 
 ##ARGS
 #collects args from commandline only if not in container otherwise variables are fed by -e VAR=VALUE 


### PR DESCRIPTION
In container mode if set the environment variable CREATE_RUN_ID the script will create for the current run a folder named after this variable instead of the default timestamp. The use case is related to unattended usage (like CI/CD) where might be useful to control this value in order to pass it to the various steps of the pipeline in order to interact with the output of the scripts.