### PR TITLE
aws provider allows to set the instance-type and disk-size when create a crc-cloud instance

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,8 +107,10 @@ Usage:
   crc-cloud create aws [flags]
 
 Flags:
-      --aws-ami-id string   AMI identifier
-  -h, --help                help for aws
+      --aws-ami-id string           AMI identifier
+      --aws-disk-size string        Disk size in GB for the machine running the cluster. Default is 100.
+      --aws-instance-type string    Instance type for the machine running the cluster. Default is c6a.2xlarge.
+  -h, --help                        help for aws
 
 Global Flags:
       --backed-url string            backed for stack state. Can be a local path with format file:///path/subpath or s3 s3://existing-bucket
@@ -140,6 +142,8 @@ podman run -d --rm \
         --output "/workspace" \
         --tags account=qe-pt,profile=builder \
         --aws-ami-id "ami-xxxx" \
+        --aws-instance-type "c6i.4xlarge" \
+        --aws-disk-size "200" \
         --pullsecret-filepath "/workspace/pullsecret" \
         --key-filepath "/workspace/id_ecdsa"
 ```

--- a/pkg/provider/aws/aws.go
+++ b/pkg/provider/aws/aws.go
@@ -27,7 +27,9 @@ func (a *Provider) ImportImageRunFunc(projectName, bundleDownloadURL, shasumfile
 
 func (a *Provider) CreateParams() map[string]string {
 	return map[string]string{
-		amiID: amiIDDesc,
+		amiID:        amiIDDesc,
+		instanceType: instanceTypeDesc,
+		diskSize:     diskSizeDesc,
 	}
 }
 

--- a/pkg/provider/aws/constants.go
+++ b/pkg/provider/aws/constants.go
@@ -3,8 +3,12 @@ package aws
 const (
 
 	// Create params
-	amiID     string = "aws-ami-id"
-	amiIDDesc string = "AMI identifier"
+	amiID            string = "aws-ami-id"
+	amiIDDesc        string = "AMI identifier"
+	instanceType     string = "aws-instance-type"
+	instanceTypeDesc string = "Instance type for the machine running the cluster. Default is c6a.2xlarge."
+	diskSize         string = "aws-disk-size"
+	diskSizeDesc     string = "Disk size in GB for the machine running the cluster. Default is 100."
 
 	// default values
 	ocpInstanceType               string = "c6a.2xlarge"


### PR DESCRIPTION
previously crc-cloud instance was created on a fixed type of machine and with a fixed size of disk, now those values can be set when create the machine, allowing to create cluster with more resources or even with different archs.

Fixes #40 