### PR TITLE
Use centos stream9 as base image for crc-cloud container

### DIFF
--- a/oci/Containerfile
+++ b/oci/Containerfile
@@ -12,7 +12,7 @@ RUN make build \
     && curl -LO ${PULUMI_URL} \
     && tar -xzvf pulumi-${PULUMI_VERSION}-linux-x64.tar.gz
 
-FROM registry.access.redhat.com/ubi9-minimal:9.2-750@sha256:0dfa71a7ec2caf445e7ac6b7422ae67f3518960bd6dbf62a7b77fa7a6cfc02b1
+FROM quay.io/centos/centos:stream9
 
 LABEL MAINTAINER "CRC <devtools-cdk@redhat.com>"
 
@@ -39,7 +39,7 @@ ARG PULUMI_AWS_VERSION=v6.2.1
 # renovate: datasource=github-releases depName=pulumi/pulumi-azure-native
 ARG PULUMI_AZURE_NATIVE_VERSION=v2.8.0
 
-RUN microdnf install -y python3 python3-pip zstd && \
+RUN dnf install -y python3 python3-pip zstd qemu-img && \
     pip install -r requirements.txt && \
     pulumi plugin install resource command ${PULUMI_COMMAND_VERSION} && \
     pulumi plugin install resource tls ${PULUMI_TLS_VERSION} && \


### PR DESCRIPTION
With #146 we missed qeu-img tool required to run the import action, that pkg is not available on ubi images, as so we need to change the base image to centos stream9 and make sure qemu-img is installed

Fixes #146 