### PR TITLE
Export the KUBECONFIG variable

### DIFF
--- a/pkg/bundle/setup/clustersetup.sh
+++ b/pkg/bundle/setup/clustersetup.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #CONST
-KUBECONFIG="/opt/kubeconfig"
+export KUBECONFIG="/opt/kubeconfig"
 LOG_PATH="${LOG_PATH:-"/tmp"}"
 LOG_FILE="${LOG_FILE:-"$LOG_PATH/_RANDOM_SUFFIX_.log"}"
 DNSMASQ_CONF="${DNSMASQ_CONF:-"/etc/dnsmasq.d/crc-dnsmasq.conf"}"


### PR DESCRIPTION
Each of the "oc" command that is veryfing the resource
is exiting with error code 1, because the KUBECONFIG is not available.

This commit is partially revert code that was proposed in [1].

[1] https://github.com/crc-org/crc-cloud/pull/189