### PR TITLE
Improve deploy-crc-cloud role

### DIFF
--- a/ansible/roles/deploy-crc-cloud/tasks/get_htpasswd.yaml
+++ b/ansible/roles/deploy-crc-cloud/tasks/get_htpasswd.yaml
@@ -1,26 +1,4 @@
 ---
-- name: Create temporary directory
-  ansible.builtin.tempfile:
-    state: directory
-  register: _temp_dir
-
-- name: Create Dockerfile
-  ansible.builtin.copy:
-    content: |
-      FROM quay.io/centos/centos:stream9-minimal
-      RUN microdnf --setopt=tsflags=nodocs --setopt=install_weak_deps=0 install -y httpd-tools
-      ENTRYPOINT ["htpasswd", "-Bbn"]
-    dest: "{{ _temp_dir.path }}/Dockerfile"
-
-- name: Build container image for htpasswd
-  ansible.builtin.command: |
-    podman build -t localhost/htpasswd:latest -f {{ _temp_dir.path }}/Dockerfile
-
 - name: "Get htpasswd for {{ user.name }}"
   ansible.builtin.shell: |
      podman run --rm -ti localhost/htpasswd:latest {{ user.name }} {{ user.password }} >> htpasswd.txt
-
-- name: Remove temporary directory
-  ansible.builtin.file:
-    path: "{{ _temp_dir.path }}"
-    state: absent

--- a/ansible/roles/deploy-crc-cloud/tasks/set_credentials.yaml
+++ b/ansible/roles/deploy-crc-cloud/tasks/set_credentials.yaml
@@ -5,11 +5,29 @@
     path: htpasswd.txt
     state: absent
 
+- name: Create temporary directory
+  ansible.builtin.tempfile:
+    state: directory
+  register: _temp_dir
+
+- name: Create Dockerfile
+  ansible.builtin.copy:
+    content: |
+      FROM quay.io/centos/centos:stream9-minimal
+      RUN microdnf --setopt=tsflags=nodocs --setopt=install_weak_deps=0 install -y httpd-tools
+      ENTRYPOINT ["htpasswd", "-Bbn"]
+    dest: "{{ _temp_dir.path }}/Dockerfile"
+
+- name: Build container image for htpasswd
+  ansible.builtin.command: |
+    podman build -t localhost/htpasswd:latest -f {{ _temp_dir.path }}/Dockerfile
+
 - name: Get htpasswd
   ansible.builtin.include_tasks: get_htpasswd.yaml
   loop: "{{ users }}"
   loop_control:
     loop_var: user
+  no_log: true
 
 - name: Cleanup htpasswd.txt file
   ansible.builtin.shell: |
@@ -25,3 +43,8 @@
 
 - name: Replace htpass-secret
   ansible.builtin.command: oc replace -f /tmp/htpass-secret.yaml
+
+- name: Remove temporary directory
+  ansible.builtin.file:
+    path: "{{ _temp_dir.path }}"
+    state: absent

--- a/ansible/roles/deploy-crc-cloud/tasks/wait_cluster_become_healthy.yaml
+++ b/ansible/roles/deploy-crc-cloud/tasks/wait_cluster_become_healthy.yaml
@@ -9,7 +9,7 @@
       retries: "{{ max_retries }}"
       delay: "{{ retry_delay }}"
       until: "'False' not in component_status.stdout_lines"
-      failed_when: "'False' in component_status.stdout_lines and retry_count >= max_retries"
+      failed_when: "'False' in component_status.stdout_lines"
       ignore_errors: true
 
     - name: Output success message if components are healthy


### PR DESCRIPTION
What changed:
- improve condition that is veryfing if cluster is healthy
- move htpasswd container image to be created task before to avoid multiple time rebuilding same image
- add "no_log" to avoid display users passwords

## Summary by Sourcery

Optimize the deploy-crc-cloud role by centralizing htpasswd image creation, securing credential output, and refining the cluster health check

Bug Fixes:
- Adjust the failure condition in wait_cluster_become_healthy to only check for unhealthy components

Enhancements:
- Build the htpasswd container image once before generating credentials to avoid repeated rebuilds
- Move temporary directory setup and cleanup into the credential task to streamline htpasswd workflow