### PR TITLE
Change retries and delay time for cluster and resource verification

### DIFF
--- a/ansible/roles/deploy-crc-cloud/defaults/main.yaml
+++ b/ansible/roles/deploy-crc-cloud/defaults/main.yaml
@@ -6,11 +6,11 @@ alternative_domain: nip.io
 
 # wait for resource
 max_retry: 20
-wait_interval: 5
+wait_interval: 15
 
 # wait cluster become healthy
 max_retries: 20
-retry_delay: 5
+retry_delay: 15
 
 pass_developer: _PASS_DEVELOPER_
 pass_kubeadmin: _PASS_KUBEADMIN_

--- a/pkg/bundle/setup/clustersetup.sh
+++ b/pkg/bundle/setup/clustersetup.sh
@@ -84,7 +84,7 @@ wait_for_resource() {
     do
         [ $retry == $max_retry ] && stop_if_failed 1 "impossible to get resource ${resource}"
         pr_info "waiting for ${resource} to become available try $retry, hang on...."
-        sleep 5
+        sleep 15
         ((retry++))
     done
 }


### PR DESCRIPTION
On crowded instances, where crc-cloud is used as CI job,
sometimes 20 retries (where delay is 5 seconds) might not be enough.
Incease the value to 20 and change delay time to 15 seconds.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Increased wait and retry intervals from 5s to 15s during deployment and cluster setup resource checks.

* **Impact**
  * Enhances reliability in slower or transiently unstable environments by reducing false failures during provisioning.
  * May slightly extend overall wait time before a failure is reported.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->