### PR TITLE
Update CentOS 9 stream container SHA-256

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,5 +1,5 @@
 run:
-  timeout: 10m
+  timeout: 15m
 
 linters:
   enable:
@@ -8,7 +8,6 @@ linters:
     - gofmt
     - gosec
     - gocritic
-    - unused 
+    - unused
     - misspell
     - revive
-

--- a/oci/Containerfile
+++ b/oci/Containerfile
@@ -12,7 +12,7 @@ RUN make build \
     && curl -LO ${PULUMI_URL} \
     && tar -xzvf pulumi-${PULUMI_VERSION}-linux-x64.tar.gz
 
-FROM quay.io/centos/centos:stream9@sha256:5e9069a89b1766ca979f0bf6eafcd4e3725adb9e873776a80ade285c65aa4fb7
+FROM quay.io/centos/centos:stream9@sha256:a2ef206db47cea339ec3b6b0f3b5f4ebf2b6888a4a62746c4c5978bdfe015b32
 
 LABEL MAINTAINER "CRC <devtools-cdk@redhat.com>"
 


### PR DESCRIPTION
Previous sha checksum is not available anymore.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated final-stage base container image to a newer CentOS Stream 9 release to pick up upstream patches and security fixes.
  * Increased CI linting timeout to improve build stability; minor whitespace normalization in linter config.
  * No user-facing functionality changes; runtime behavior remains unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->